### PR TITLE
Remove .only from a describe statement.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -69,7 +69,7 @@ describe("Board", function(){
 })
 
 describe("Game", function(){
-	describe.only("#placePiece", function(){
+	describe("#placePiece", function(){
 		var testGame = new Game();
 		it("should allow a player to make a valid move", function(){
 			testGame.placePiece([3, 2], "black");


### PR DESCRIPTION
The .only caused only (duh) that describe statement to get run when running Mocha tests.
